### PR TITLE
Dongilbert feature universal dnc

### DIFF
--- a/app/bundles/EmailBundle/Model/EmailModel.php
+++ b/app/bundles/EmailBundle/Model/EmailModel.php
@@ -1219,7 +1219,9 @@ class EmailModel extends FormModel
             /** @var \Mautic\LeadBundle\Model\LeadModel $leadModel */
             $leadModel = $this->factory->getModel('lead.lead');
 
-            $leadModel->addDncForLead($lead, 'email', $comments, $reason, $flush);
+            $email   = $stat->getEmail();
+            $channel = ($email) ? array('email' => $email->getId()) : 'email';
+            $leadModel->addDncForLead($lead, $channel, $comments, $reason, $flush);
         }
     }
 
@@ -1519,7 +1521,7 @@ class EmailModel extends FormModel
 
         if (isset($options['groupBy']) && $options['groupBy'] == 'reads') {
             $chartQuery->applyDateFilters($q, 'date_read');
-        }        
+        }
 
         $results = $q->execute()->fetchAll();
 

--- a/app/bundles/LeadBundle/Entity/DoNotContact.php
+++ b/app/bundles/LeadBundle/Entity/DoNotContact.php
@@ -71,6 +71,8 @@ class DoNotContact
      */
     private $channel;
 
+    private $channelId;
+
     /**
      * @param ORM\ClassMetadata $metadata
      */
@@ -80,7 +82,7 @@ class DoNotContact
 
         $builder->setTable('lead_donotcontact')
             ->setCustomRepositoryClass('Mautic\LeadBundle\Entity\DoNotContactRepository')
-            ->addIndex(array('reason'), 'dnc_search');
+            ->addIndex(array('reason'), 'dnc_reason_search');
 
         $builder->addId();
 
@@ -88,11 +90,13 @@ class DoNotContact
 
         $builder->addDateAdded();
 
-        $builder->createField('reason', 'integer')
+        $builder->createField('reason', 'smallint')
             ->build();
 
         $builder->createField('channel', 'string')
             ->build();
+
+        $builder->addNamedField('channelId', 'integer', 'channel_id', true);
 
         $builder->createField('comments', 'text')
             ->nullable()
@@ -129,6 +133,24 @@ class DoNotContact
     public function setChannel($channel)
     {
         $this->channel = $channel;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getChannelId()
+    {
+        return $this->channelId;
+    }
+
+    /**
+     * @param mixed $channelId
+     *
+     * @return DoNotContact
+     */
+    public function setChannelId($channelId)
+    {
+        $this->channelId = $channelId;
     }
 
     /**

--- a/app/bundles/LeadBundle/Model/LeadModel.php
+++ b/app/bundles/LeadBundle/Model/LeadModel.php
@@ -889,11 +889,11 @@ class LeadModel extends FormModel
     /**
      * Create a DNC entry for a lead
      *
-     * @param Lead $lead
-     * @param string $channel
-     * @param string $comments
-     * @param int $reason
-     * @param bool $flush
+     * @param Lead         $lead
+     * @param string|array $channel  If an array with an ID, use the structure ['email' => 123]
+     * @param string       $comments
+     * @param int          $reason
+     * @param bool         $flush
      *
      * @return boolean If a DNC entry is added or updated, returns true. If a DNC is already present
      *                 and has the specified reason, nothing is done and this returns false.
@@ -906,6 +906,14 @@ class LeadModel extends FormModel
         // If they don't have a DNC entry yet
         if ($isContactable === DoNotContact::IS_CONTACTABLE) {
             $dnc = new DoNotContact();
+
+            if (is_array($channel)) {
+                $channelId = reset($channel);
+                $channel   = key($channel);
+
+                $dnc->setChannelId((int) $channelId);
+            }
+
             $dnc->setChannel($channel);
             $dnc->setReason($reason);
             $dnc->setLead($lead);
@@ -1459,7 +1467,7 @@ class LeadModel extends FormModel
             $all = $query->fetchTimeData('leads', 'date_added', $filter);
             $chart->setDataset($allLeadsT, $all);
         }
-        
+
         return $chart->render();
     }
 

--- a/app/migrations/Version20160426000000.php
+++ b/app/migrations/Version20160426000000.php
@@ -12,12 +12,16 @@ namespace Mautic\Migrations;
 use Doctrine\DBAL\Migrations\SkipMigrationException;
 use Doctrine\DBAL\Schema\Schema;
 use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+use Mautic\LeadBundle\Entity\DoNotContact;
 
 /**
  * Universal DNC Migration
  */
 class Version20160426000000 extends AbstractMauticMigration
 {
+    private $leadIdIdx;
+    private $leadIdFk;
+
     /**
      * @param Schema $schema
      *
@@ -29,6 +33,9 @@ class Version20160426000000 extends AbstractMauticMigration
         if ($schema->hasTable($this->prefix.'lead_donotcontact')) {
             throw new SkipMigrationException('Schema includes this migration');
         }
+
+        $this->leadIdIdx = $this->generatePropertyName($this->prefix . 'lead_donotcontact', 'idx', array('lead_id'));
+        $this->leadIdFk  = $this->generatePropertyName($this->prefix . 'lead_donotcontact', 'fk', array('lead_id'));
     }
 
     /**
@@ -36,8 +43,6 @@ class Version20160426000000 extends AbstractMauticMigration
      */
     public function mysqlUp(Schema $schema)
     {
-        $leadIdIdx = $this->generatePropertyName($this->prefix . 'lead_donotcontact', 'idx', array('lead_id'));
-        $leadIdFk = $this->generatePropertyName($this->prefix . 'lead_donotcontact', 'fk', array('lead_id'));
 
         $sql = <<<SQL
 CREATE TABLE `{$this->prefix}lead_donotcontact` (
@@ -46,11 +51,12 @@ CREATE TABLE `{$this->prefix}lead_donotcontact` (
   `channel` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
   `channel_id` int(11) DEFAULT NULL,
   `date_added` datetime NOT NULL COMMENT '(DC2Type:datetime)',
-  `reason` tinyint(1) NOT NULL DEFAULT '0',
+  `reason` smallint NOT NULL,
   `comments` longtext COLLATE utf8_unicode_ci,
   PRIMARY KEY (`id`),
-  KEY `{$leadIdIdx}` (`lead_id`),
-  CONSTRAINT `{$leadIdFk}` FOREIGN KEY (`lead_id`) REFERENCES `{$this->prefix}leads` (`id`) ON DELETE CASCADE
+  KEY `{$this->leadIdIdx}` (`lead_id`),
+  KEY `{$this->prefix}dnc_reason_search` (`reason`),
+  CONSTRAINT `{$this->leadIdFk}` FOREIGN KEY (`lead_id`) REFERENCES `{$this->prefix}leads` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 SQL;
 
@@ -62,6 +68,89 @@ SQL;
      */
     public function postgresqlUp(Schema $schema)
     {
-        
+        $this->addSql("CREATE SEQUENCE {$this->prefix}lead_donotcontact_id_seq INCREMENT BY 1 MINVALUE 1 START 1");
+
+        $sql = <<<SQL
+CREATE TABLE {$this->prefix}lead_donotcontact (
+  id INT NOT NULL, 
+  lead_id INT DEFAULT NULL, 
+  date_added TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, 
+  reason INT NOT NULL, 
+  channel VARCHAR(255) NOT NULL, 
+  channel_id INT DEFAULT NULL, 
+  comments TEXT DEFAULT NULL, 
+  PRIMARY KEY(id)
+);
+SQL;
+
+        $this->addSql($sql);
+
+        $this->addSql("CREATE INDEX {$this->leadIdIdx} ON {$this->prefix}lead_donotcontact (lead_id)");
+        $this->addSql("CREATE INDEX {$this->prefix}dnc_reason_search ON {$this->prefix}lead_donotcontact (reason)");
+        $this->addSql("COMMENT ON COLUMN {$this->prefix}lead_donotcontact.date_added IS '(DC2Type:datetime)'");
+        $this->addSql("ALTER TABLE {$this->prefix}lead_donotcontact ADD CONSTRAINT {$this->leadIdFk} FOREIGN KEY (lead_id) REFERENCES {$this->prefix}leads (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE");
+    }
+
+    /**
+     * Migrate existing email_donotemail entries to the new lead_donotcontact format
+     *
+     * @param Schema $schema
+     */
+    public function postUp(Schema $schema)
+    {
+        $logger = $this->factory->getLogger();
+        $qb = $this->connection->createQueryBuilder();
+
+        $qb->select('dne.email_id, dne.lead_id, dne.date_added, dne.unsubscribed, dne.bounced, dne.manual, dne.comments')
+            ->from($this->prefix.'email_donotemail', 'dne')
+            ->setMaxResults(500);
+
+        $start = 0;
+        while ($results = $qb->execute()->fetchAll()) {
+            // Start a transaction
+            $this->connection->beginTransaction();
+
+            foreach ($results as $row) {
+                // Build the new format
+                if (empty($row['lead_id'])) {
+                    continue;
+                }
+
+                $insert = array(
+                    'lead_id'    => $row['lead_id'],
+                    'channel'    => 'email',
+                    'channel_id' => $row['email_id'],
+                    'date_added' => $row['date_added'],
+                    'comments'   => $row['comments']
+                );
+
+                switch (true) {
+                    case (!empty($row['unsubscribed'])):
+                        $insert['reason'] = DoNotContact::UNSUBSCRIBED;
+                        break;
+                    case (!empty($row['bounced'])):
+                        $insert['reason'] = DoNotContact::BOUNCED;
+                        break;
+                    default:
+                        $insert['reason'] = DoNotContact::MANUAL;
+                        break;
+                }
+
+                $this->connection->insert($this->prefix.'lead_donotcontact', $insert);
+                unset($insert);
+            }
+
+            try {
+                $this->connection->commit();
+            } catch (\Exception $e) {
+                $this->connection->rollBack();
+
+                $logger->addError($e->getMessage(), array('exception' => $e));
+            }
+
+            // Increase the start
+            $start += 500;
+            $qb->setFirstResult($start);
+        }
     }
 }


### PR DESCRIPTION
Please answer the following questions:

| Q | A |
| --- | --- |
| Bug fix? | N |
| New feature? | N |
| BC breaks? | N |
| Deprecations? | N |
| Fixed issues |  |
## Description
1. adds support to track channel_id if applicable.
2. adds postgresql queries (had to rename the dnc_search index to make pg happy)
3. migrates data from email_donotemail to lead_donotcontact
4. updates the mysql queries to match what Doctrine generates (so that doctrine:schema:update does detect a difference)
## Steps to test this PR
1. Delete 20160426000000 from the migrations table if already there and lead_donotcontact table so that the migration will run again
2. Manually populate some legit data in email_donotemail if you don't already have any
3. Run the migration which should be successful and lead_donotcontact should be correctly populated
4. If you have PG, run migrations against it which should also be successful.
