### PR TITLE
Fixed migrating email_donotemail data for Postgresql

### DIFF
--- a/app/bundles/EmailBundle/Entity/EmailRepository.php
+++ b/app/bundles/EmailBundle/Entity/EmailRepository.php
@@ -34,7 +34,8 @@ class EmailRepository extends CommonRepository
             ->from(MAUTIC_TABLE_PREFIX . 'lead_donotcontact', 'dnc')
             ->leftJoin('dnc', MAUTIC_TABLE_PREFIX . 'leads', 'l', 'l.id = dnc.lead_id')
             ->where('dnc.channel = "email"')
-            ->andWhere('l.email != ""');
+            ->andWhere($q->expr()->neq('l.email', $q->expr()->literal('')));
+
 
         $results = $q->execute()->fetchAll();
 

--- a/app/migrations/Version20160426000000.php
+++ b/app/migrations/Version20160426000000.php
@@ -75,7 +75,7 @@ CREATE TABLE {$this->prefix}lead_donotcontact (
   id INT NOT NULL, 
   lead_id INT DEFAULT NULL, 
   date_added TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, 
-  reason INT NOT NULL, 
+  reason SMALLINT NOT NULL, 
   channel VARCHAR(255) NOT NULL, 
   channel_id INT DEFAULT NULL, 
   comments TEXT DEFAULT NULL, 
@@ -124,6 +124,14 @@ SQL;
                     'comments'   => $row['comments']
                 );
 
+                if ('postgresql' == $this->platform) {
+                    // Get ID from sequence
+                    $nextVal = (int)$this->connection->fetchColumn(
+                        $this->connection->getDatabasePlatform()->getSequenceNextValSQL("{$this->prefix}lead_donotcontact_id_seq")
+                    );
+                    $insert['id'] = $nextVal;
+                }
+
                 switch (true) {
                     case (!empty($row['unsubscribed'])):
                         $insert['reason'] = DoNotContact::UNSUBSCRIBED;
@@ -137,6 +145,7 @@ SQL;
                 }
 
                 $this->connection->insert($this->prefix.'lead_donotcontact', $insert);
+
                 unset($insert);
             }
 


### PR DESCRIPTION
Please answer the following questions:

| Q | A |
| --- | --- |
| Bug fix? | Y |
| New feature? | N |
| BC breaks? | N |
| Deprecations? | N |
| Fixed issues |  |
## Description

Use this PR over #3 as John is out for the weekend. This fixes the data migration for PostgreSQL while keeping the schema in sync with what Doctrine expects. 

I also ported in his fix for the literal string in one of the queries. https://github.com/dongilbert/mautic/pull/3/files#diff-0a57a38fe0f4a3539c8da657ac8f98a2R37
