### PR TITLE
Disabled list filters and category for now.

### DIFF
--- a/app/bundles/NotificationBundle/Config/config.php
+++ b/app/bundles/NotificationBundle/Config/config.php
@@ -114,9 +114,9 @@ return array(
             )
         )
     ),
-    'categories' => array(
-        'notification' => null
-    ),
+    //'categories' => array(
+    //    'notification' => null
+    //),
     'parameters' => array(
         'notification_enabled' => false,
         'notification_app_id' => null,

--- a/app/bundles/NotificationBundle/Views/Notification/index.html.php
+++ b/app/bundles/NotificationBundle/Views/Notification/index.html.php
@@ -22,7 +22,7 @@ $view['slots']->set("headerTitle", $view['translator']->trans('mautic.notificati
         'templateButtons' => array(
             'delete' => $permissions['notification:notifications:deleteown'] || $permissions['notification:notifications:deleteother']
         ),
-        'filters'     => $filters
+        //'filters'     => $filters //@todo
     )); ?>
 
     <div class="page-list">


### PR DESCRIPTION
Please answer the following questions:

| Q | A |
| --- | --- |
| Bug fix? | Y |
| New feature? | N |
| BC breaks? | N |
| Deprecations? | N |
| Fixed issues |  |
## Description

This simply removes category and list view filters for notifications till they are implemented.
## Steps to reproduce the bug (if applicable)

Attempting to use the list/category filter results in a query error.
## Steps to test this PR

Got to Web Notifications under channels and attempt to use the dropdown filter. It should error. Log out (to clear the session), apply the PR, and the filter should be gone. 
