### PR TITLE
Mark notifications as read rather than delete

### DIFF
--- a/app/bundles/CoreBundle/Assets/js/1.core.js
+++ b/app/bundles/CoreBundle/Assets/js/1.core.js
@@ -2806,18 +2806,12 @@ var Mautic = {
     /**
      * Marks notifications as read and clears unread indicators
      */
-    markNotificationsRead: function () {
+    showNotifications: function () {
         mQuery("#notificationsDropdown").unbind('hide.bs.dropdown');
         mQuery('#notificationsDropdown').on('hidden.bs.dropdown', function () {
             if (!mQuery('#newNotificationIndicator').hasClass('hide')) {
                 mQuery('#notifications .is-unread').remove();
                 mQuery('#newNotificationIndicator').addClass('hide');
-
-                mQuery.ajax({
-                    url: mauticAjaxUrl,
-                    type: "GET",
-                    data: "action=markNotificationsRead"
-                });
             }
         });
     },

--- a/app/bundles/CoreBundle/Controller/AjaxController.php
+++ b/app/bundles/CoreBundle/Controller/AjaxController.php
@@ -75,7 +75,7 @@ class AjaxController extends CommonController
                 $parts     = explode(":", $action);
                 $namespace = 'Mautic';
                 $isPlugin  = false;
-                
+
                 if (count($parts) == 3 && $parts['0'] == 'plugin') {
                     $namespace = 'MauticPlugin';
                     array_shift($parts);
@@ -671,21 +671,6 @@ class AjaxController extends CommonController
 
             $model->setOnlineStatus($status);
         }
-
-        return $this->sendJsonResponse(array('success' => 1));
-    }
-
-    /**
-     * @param Request $request
-     *
-     * @return JsonResponse
-     */
-    protected function markNotificationsReadAction(Request $request)
-    {
-        /** @var \Mautic\CoreBundle\Model\NotificationModel $model */
-        $model = $this->getModel('core.notification');
-
-        $model->markAllRead();
 
         return $this->sendJsonResponse(array('success' => 1));
     }

--- a/app/bundles/CoreBundle/Controller/CommonController.php
+++ b/app/bundles/CoreBundle/Controller/CommonController.php
@@ -68,9 +68,9 @@ class CommonController extends Controller implements MauticController
 
     /**
      * Check if a security level is granted
-     * 
+     *
      * @param $level
-     * 
+     *
      * @return bool
      */
     protected function accessGranted($level)
@@ -81,7 +81,7 @@ class CommonController extends Controller implements MauticController
     /**
      * Override this method in your controller
      * for easy access to the permissions
-     * 
+     *
      * @return array
      */
     protected function getPermissions()
@@ -571,7 +571,7 @@ class CommonController extends Controller implements MauticController
      * @param string $domain
      * @param bool   $addNotification
      */
-    public function addFlash($message, $messageVars = array(), $type = 'notice', $domain = 'flashes', $addNotification = true)
+    public function addFlash($message, $messageVars = array(), $type = 'notice', $domain = 'flashes', $addNotification = false)
     {
         if ($domain == null) {
             $domain = 'flashes';

--- a/app/bundles/CoreBundle/Entity/Notification.php
+++ b/app/bundles/CoreBundle/Entity/Notification.php
@@ -67,7 +67,10 @@ class Notification
         $builder = new ClassMetadataBuilder($metadata);
 
         $builder->setTable('notifications')
-            ->setCustomRepositoryClass('Mautic\CoreBundle\Entity\NotificationRepository');
+            ->setCustomRepositoryClass('Mautic\CoreBundle\Entity\NotificationRepository')
+            ->addIndex(['is_read'], 'notification_read_status')
+            ->addIndex(['type'], 'notification_type')
+            ->addIndex(['is_read', 'user_id'], 'notification_user_read_status');
 
         $builder->addId();
 

--- a/app/bundles/CoreBundle/Entity/NotificationRepository.php
+++ b/app/bundles/CoreBundle/Entity/NotificationRepository.php
@@ -63,6 +63,71 @@ class NotificationRepository extends CommonRepository
             $filter['id'] = (int) $id;
         }
 
-        $this->_em->getConnection()->delete(MAUTIC_TABLE_PREFIX . 'notifications', $filter);
+        $this->_em->getConnection()->update(MAUTIC_TABLE_PREFIX . 'notifications', ['is_read' => 1], $filter);
+    }
+
+    /**
+     * @return mixed|null
+     */
+    public function getUpstreamLastDate()
+    {
+        $qb = $this->createQueryBuilder('n')
+            ->select('partial n.{id, dateAdded}')
+            ->where('n.type = :type')
+            ->setParameter('type', 'upstream')
+            ->setMaxResults(1);
+
+        /** @var Notification $result */
+        $result = $qb->getQuery()->getOneOrNullResult();
+
+        return $result === null ? null : $result->getDateAdded();
+    }
+
+    /**
+     * Fetch notifications for this user
+     *
+     * @param      $userId
+     * @param null $afterId
+     * @param bool $includeRead
+     * @param null $type
+     *
+     * @return array
+     */
+    public function getNotifications($userId, $afterId = null, $includeRead = false, $type = null)
+    {
+        $qb = $this->createQueryBuilder('n');
+
+        $expr = $qb->expr()->andX();
+
+        if ($userId) {
+            $expr->add(
+                $qb->expr()->eq('IDENTITY(n.user)', $userId)
+            );
+        }
+
+        if ($afterId) {
+            $expr->add(
+                $qb->expr()->gt('n.id', (int) $afterId)
+            );
+        }
+
+        if (!$includeRead) {
+            $expr->add(
+                $qb->expr()->eq('n.isRead', 0)
+            );
+        }
+
+        if (null !== $type) {
+            $expr->add(
+                $qb->expr()->eq('n.type', ':type')
+            );
+            $qb->setParameter('type', $type);
+        }
+
+        if ($expr->count()) {
+            $qb->where($expr);
+        }
+
+        return $qb->getQuery()->getArrayResult();
     }
 }

--- a/app/bundles/CoreBundle/Entity/NotificationRepository.php
+++ b/app/bundles/CoreBundle/Entity/NotificationRepository.php
@@ -97,13 +97,9 @@ class NotificationRepository extends CommonRepository
     {
         $qb = $this->createQueryBuilder('n');
 
-        $expr = $qb->expr()->andX();
-
-        if ($userId) {
-            $expr->add(
-                $qb->expr()->eq('IDENTITY(n.user)', $userId)
-            );
-        }
+        $expr = $qb->expr()->andX(
+            $qb->expr()->eq('IDENTITY(n.user)', $userId)
+        );
 
         if ($afterId) {
             $expr->add(
@@ -124,9 +120,7 @@ class NotificationRepository extends CommonRepository
             $qb->setParameter('type', $type);
         }
 
-        if ($expr->count()) {
-            $qb->where($expr);
-        }
+        $qb->where($expr);
 
         return $qb->getQuery()->getArrayResult();
     }

--- a/app/bundles/CoreBundle/Model/NotificationModel.php
+++ b/app/bundles/CoreBundle/Model/NotificationModel.php
@@ -178,7 +178,8 @@ class NotificationModel extends FormModel
 
         $this->updateUpstreamNotifications();
 
-        $notifications = $this->getRepository()->getNotifications($afterId, null, $includeRead);
+        $userId        = ($this->user) ? $this->user->getId() : 0;
+        $notifications = $this->getRepository()->getNotifications($userId, $afterId, $includeRead);
 
         $showNewIndicator = false;
 
@@ -254,8 +255,10 @@ class NotificationModel extends FormModel
         foreach ($feed->getItems() as $item) {
             $description = $item->getDescription();
             if (mb_strlen(strip_tags($description)) > 300) {
-                $description  = mb_substr(strip_tags($description), 0, 300);
-                $description .= "... <a href=\"".$item->getLink()."\" target=\"_blank\">".$this->translator->trans('mautic.core.notification.read_more')."</a>";
+                $description = mb_substr(strip_tags($description), 0, 300);
+                $description .= "... <a href=\"".$item->getLink()."\" target=\"_blank\">".$this->translator->trans(
+                        'mautic.core.notification.read_more'
+                    )."</a>";
             }
             $header = $item->getTitle();
 

--- a/app/bundles/CoreBundle/Translations/en_US/messages.ini
+++ b/app/bundles/CoreBundle/Translations/en_US/messages.ini
@@ -231,6 +231,7 @@ mautic.core.noresults="Seems there are none! Try changing a filter (if applicabl
 mautic.core.noresults.header="No Results Found"
 mautic.core.noresults.tip="Hey! How about a tip?"
 mautic.core.not_required="Not required"
+mautic.core.notification.read_more="[Read More]"
 mautic.core.notifications="Notifications"
 mautic.core.notifications.clear="Clear this notification"
 mautic.core.notifications.clearall="Clear all notifications"

--- a/app/bundles/CoreBundle/Views/Notification/notifications.html.php
+++ b/app/bundles/CoreBundle/Views/Notification/notifications.html.php
@@ -9,7 +9,7 @@
 ?>
 
 <li class="dropdown dropdown-custom" id="notificationsDropdown">
-    <a href="javascript: void(0);" onclick="Mautic.markNotificationsRead();" class="dropdown-toggle dropdown-notification" data-toggle="dropdown">
+    <a href="javascript: void(0);" onclick="Mautic.showNotifications();" class="dropdown-toggle dropdown-notification" data-toggle="dropdown">
         <?php $hideClass = (!empty($updateMessage['isNew']) || !empty($showNewIndicator)) ? '' : ' hide'; ?>
         <span class="label label-danger<?php echo $hideClass; ?>" id="newNotificationIndicator"><i class="fa fa-asterisk"></i></span>
         <span class="fa fa-bell fs-16"></span>

--- a/app/migrations/Version20160805000123.php
+++ b/app/migrations/Version20160805000123.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2016 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\Migrations;
+
+use Doctrine\DBAL\Migrations\SkipMigrationException;
+use Doctrine\DBAL\Schema\Schema;
+use Mautic\CoreBundle\Doctrine\AbstractMauticMigration;
+/**
+ * Class Version20160805000123
+ */
+class Version20160805000123 extends AbstractMauticMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function preUp(Schema $schema)
+    {
+        if ($schema->getTable("{$this->prefix}notifications")->hasIndex("{$this->prefix}notification_read_status")) {
+
+            throw new SkipMigrationException('Schema includes this migration');
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->addSql("CREATE INDEX {$this->prefix}notification_read_status ON {$this->prefix}notifications (is_read)");
+        $this->addSql("CREATE INDEX {$this->prefix}notification_type ON {$this->prefix}notifications (type)");
+        $this->addSql("CREATE INDEX {$this->prefix}notification_user_read_status ON {$this->prefix}notifications (is_read, user_id)");
+    }
+}


### PR DESCRIPTION
This PR changes notifications behavior to not delete but mark as read and not show is read notifications in the notification tray. 

It also updates the upstream notifications to leverage header/link in case we later want to utilize a full blog announcement. 
